### PR TITLE
Yara 3.9 support

### DIFF
--- a/common_helper_yara/__init__.py
+++ b/common_helper_yara/__init__.py
@@ -1,3 +1,4 @@
+from .common import get_yara_version
 from .yara_scan import scan
 from .yara_compile import compile_rules
 from .yara_interpretation import get_all_matched_strings
@@ -5,5 +6,6 @@ from .yara_interpretation import get_all_matched_strings
 __all__ = [
     'scan',
     'compile_rules',
-    'get_all_matched_strings'
-    ]
+    'get_all_matched_strings',
+    'get_yara_version',
+]

--- a/common_helper_yara/common.py
+++ b/common_helper_yara/common.py
@@ -1,5 +1,23 @@
-def convert_external_variables(ext_var_dict):
-    output = []
-    for ext_var in ext_var_dict:
-        output.append('-d {}={}'.format(ext_var, ext_var_dict[ext_var]))
-    return " ".join(sorted(output))
+import logging
+from distutils.version import LooseVersion
+from shlex import split
+from subprocess import check_output
+from typing import Any, Dict, Optional
+
+
+def convert_external_variables(ext_var_dict: Dict[str, Any]) -> str:
+    output = [f'-d {variable}={value}' for variable, value in ext_var_dict.items()]
+    return ' '.join(sorted(output))
+
+
+def get_yara_version() -> Optional[LooseVersion]:
+    '''
+    Returns the YARA version as `distutils.version.LooseVersion` or None if YARA is not found.
+
+    :return: The installed YARA version or `None`
+    '''
+    try:
+        return LooseVersion(check_output(split('yara --version')).decode().strip())
+    except FileNotFoundError:
+        logging.warning('YARA not found. Is YARA installed?', exc_info=True)
+        return None

--- a/common_helper_yara/yara_compile.py
+++ b/common_helper_yara/yara_compile.py
@@ -31,7 +31,7 @@ def compile_rules(
 def _create_joint_signature_file(directory: Path, tmp_file: NamedTemporaryFile):
     all_signatures = [
         signature_file.read_bytes()
-        for signature_file in directory.iterdir()
+        for signature_file in sorted(directory.iterdir())
     ]
     Path(tmp_file.name).write_bytes(b'\n'.join(all_signatures))
 

--- a/common_helper_yara/yara_interpretation.py
+++ b/common_helper_yara/yara_interpretation.py
@@ -1,19 +1,22 @@
-def get_all_matched_strings(yara_result_dict):
-    '''
-    returns a set of all matched strings
+from typing import Set
 
-    :param yara_result_dict: a result dict
-    :type yara_result_dict: dict
-    :return: set
+
+def get_all_matched_strings(yara_result_dict: dict) -> Set[str]:
     '''
-    matched_strings = set()
-    for matched_rule in yara_result_dict:
-        matched_strings.update(_get_matched_strings_of_single_rule(yara_result_dict[matched_rule]))
-    return matched_strings
+    Get all strings matched by the yara rules
+
+    :param yara_result_dict: a yara result dict
+    :return: a set of all matched strings
+    '''
+    return {
+        string
+        for matched_rule in yara_result_dict.values()
+        for string in _get_matched_strings_of_single_rule(matched_rule)
+    }
 
 
 def _get_matched_strings_of_single_rule(yara_match):
-    matched_strings = set()
-    for string_item in yara_match['strings']:
-        matched_strings.add(string_item[2].decode('utf-8', 'replace'))
-    return matched_strings
+    return {
+        string_item[2].decode('utf-8', 'replace')
+        for string_item in yara_match['strings']
+    }

--- a/common_helper_yara/yara_scan.py
+++ b/common_helper_yara/yara_scan.py
@@ -62,7 +62,7 @@ def _split_output_in_rules_and_matches(output):
     while '' in match_blocks:
         match_blocks.remove('')
 
-    rule_regex = re.compile(r'(.*)\s\[(.*)]\s([/]|[./])(.+)')
+    rule_regex = re.compile(r'(.*)\s\[(.*)]\s(?=/|./|../)(.+)')
     rules = rule_regex.findall(output)
 
     assert len(match_blocks) == len(rules)
@@ -70,17 +70,15 @@ def _split_output_in_rules_and_matches(output):
 
 
 def _append_match_to_result(match, resulting_matches, rule):
-    assert len(rule) == 4
-    rule_name, meta_string, _, _ = rule
-    assert len(match) == 4
+    assert len(rule) == 3, f'rule was parsed incorrectly: {rule}'
+    rule_name, meta_string, _ = rule
+    assert len(match) == 4, f'match was parsed incorrectly: {match}'
     _, offset, matched_tag, matched_string = match
 
     meta_dict = _parse_meta_data(meta_string)
 
-    this_match = resulting_matches[rule_name] if rule_name in resulting_matches else dict(rule=rule_name, matches=True, strings=list(), meta=meta_dict)
-
+    this_match = resulting_matches.setdefault(rule_name, dict(rule=rule_name, matches=True, strings=[], meta=meta_dict))
     this_match['strings'].append((int(offset, 16), matched_tag, matched_string.encode()))
-    resulting_matches[rule_name] = this_match
 
 
 def _parse_meta_data(meta_data_string):

--- a/common_helper_yara/yara_scan.py
+++ b/common_helper_yara/yara_scan.py
@@ -36,7 +36,7 @@ def scan(
         scan_result = check_output(command, shell=True, stderr=STDOUT)
         return _parse_yara_output(scan_result.decode())
     except CalledProcessError as e:
-        logging.error(f"There seems to be an error in the rule file:\n{e.output.decode()}")
+        logging.error(f'There seems to be an error in the rule file:\n{e.output.decode()}', exc_info=True)
         return {}
     except Exception as e:
         logging.error(f'Could not parse yara result: {e}', exc_info=True)

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,11 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.2.1"
+VERSION = "0.3"
 
 setup(
     name="common_helper_yara",
     version=VERSION,
     packages=find_packages(),
-    install_requires=[
-        'common_helper_files @ git+https://github.com/fkie-cad/common_helper_files.git'
-    ],
     extras_require={
         'dev': [
             'pytest',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,10 +1,29 @@
-import unittest
+from distutils.version import LooseVersion
 
-from common_helper_yara.common import convert_external_variables
+import pytest
+
+import common_helper_yara.common as common
+from common_helper_yara.common import convert_external_variables, get_yara_version
 
 
-class TestYaraCommon(unittest.TestCase):
+@pytest.mark.parametrize('test_input, expected_output', [
+    ({'a': 'b'}, '-d a=b'),
+    ({'a': 1, 'b': 'c'}, '-d a=1 -d b=c'),
+])
+def test_convert_external_variables(test_input, expected_output):
+    assert convert_external_variables(test_input) == expected_output
 
-    def test_convert_external_variables(self):
-        self.assertEqual(convert_external_variables({'a': 'b'}), '-d a=b', 'converted output not correct')
-        self.assertEqual(convert_external_variables({'a': 1, 'b': 'c'}), '-d a=1 -d b=c', 'converted output not correct')
+
+def test_get_yara_version():
+    assert LooseVersion('3.0') < get_yara_version() < LooseVersion('5.0')
+
+
+@pytest.fixture()
+def yara_not_found(monkeypatch):
+    def raise_error(_):
+        raise FileNotFoundError
+    monkeypatch.setattr(common, 'check_output', raise_error)
+
+
+def test_get_yara_version_error(yara_not_found):
+    assert get_yara_version() is None

--- a/tests/test_interpretation.py
+++ b/tests/test_interpretation.py
@@ -1,13 +1,18 @@
-import unittest
 from common_helper_yara.yara_interpretation import get_all_matched_strings
 
+TEST_DATA = {
+    'test_rule': {
+        'rule': 'test_rule', 'meta': {},
+        'strings': [(0, '$a', b'test_1'), (10, '$b', b'test_2')],
+        'matches': True
+    },
+    'test_rule2': {
+        'rule': 'test_rule2',
+        'meta': {},
+        'strings': [(0, '$a', b'test_1'), (10, '$b', b'test_3')], 'matches': True
+    },
+}
 
-class TestYaraInterpretation(unittest.TestCase):
 
-    def test_get_all_matched_strings(self):
-        test_data = {
-            'test_rule': {'rule': 'test_rule', 'meta': {}, 'strings': [(0, '$a', b'test_1'), (10, '$b', b'test_2')], 'matches': True},
-            'test_rule2': {'rule': 'test_rule2', 'meta': {}, 'strings': [(0, '$a', b'test_1'), (10, '$b', b'test_3')], 'matches': True},
-            }
-        result = get_all_matched_strings(test_data)
-        self.assertEqual(result, set(['test_1', 'test_2', 'test_3']), "resulting strings not correct")
+def test_get_all_matched_strings():
+    assert get_all_matched_strings(TEST_DATA) == {'test_1', 'test_2', 'test_3'}, "resulting strings not correct"


### PR DESCRIPTION
- added `compiled` parameter to `scan` function to support yara versions >= 3.9 in combination with pre-compiled rules
- added `get_yara_version` function
- added tests
- refactoring
- removed `common_helper_files` dependency